### PR TITLE
chore: better caches

### DIFF
--- a/setup-go/action.yml
+++ b/setup-go/action.yml
@@ -31,12 +31,12 @@ runs:
       uses: actions/cache@v2
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
-        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-build-${{ github.ref }}-${{ hashFiles('**/go.sum', '**/Makefile') }}
     - name: Go Mod Cache
       uses: actions/cache@v2
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
-        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum', '**/Makefile') }}
     - name: Add ~/go/bin to PATH
       shell: bash
       run: |
@@ -47,6 +47,9 @@ runs:
         go install golang.org/x/tools/cmd/goimports@latest
         export BINDIR=/home/runner/go/bin
         curl -sfL https://git.io/fhJZU | /bin/bash
+    - name: Download all Go modules
+      run: |
+        go mod download
     - uses: benjlevesque/short-sha@v1.2
       id: short-sha
       with:
@@ -63,3 +66,4 @@ runs:
         echo "::set-output name=go-build-version::$goModuleBuildVersion"
         echo "::set-output name=build-version::$svermakerBuildVersion"
         echo "::set-output name=helm-label::$svermakerHelmLabel"
+        


### PR DESCRIPTION
try better cache meachnics. 

* download the all go mod packages
* add makefile to the hash so we get a cache miss on tool install changes
* add github .ref to go build cache to reuse build cache for brances