### PR TITLE
ci(tag): checkout do not do a shallow clone

### DIFF
--- a/.github/workflows/golang-tag.yml
+++ b/.github/workflows/golang-tag.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: "☁️checkout repository"
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: "☁️ checkout action repository"
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Doing a shallow clone causes problems resolving the changelog